### PR TITLE
修复一个多买土地吞钱的bug

### DIFF
--- a/src/farmer.ts
+++ b/src/farmer.ts
@@ -461,7 +461,7 @@ export class Farmer {
     if (this.money < totalPrice) {
       return `嗯...你的金币不够购买${quantity}个${item}。`;
     }
-    if (quantity > 1) {
+    if (quantity > 1 && (item === "扩容田地" || item === "扩容田地ii") ) {
       return `田地买多了,最多买一个`; //这里我随便加了一个返回，不让买就行了
     }
     else {

--- a/src/farmer.ts
+++ b/src/farmer.ts
@@ -461,31 +461,35 @@ export class Farmer {
     if (this.money < totalPrice) {
       return `嗯...你的金币不够购买${quantity}个${item}。`;
     }
-
-    if (item === "扩容田地") {
-      let level = globalStore[item].level;
-      if (this.purchasedFields[level]) {
-        return `你已经购买过该等级的扩容田地啦！`;
-      }
-      this.fields += quantity;
-      this.purchasedFields[level] = true;
-    } else if (item === "扩容田地ii") {
-      if (this.purchasedFields[5]) {
-        return `你已经购买过5级扩容田地啦！`;
-      }
-      this.fields += 1; // 5级扩容田地一次只能购买一个
-      this.purchasedFields[5] = true;
-      delete globalStore["扩容田地ii"]; // 购买后从商店消失
-    } else {
-      if (!this.warehouse[item]) {
-        this.warehouse[item] = 0;
-      }
-      this.warehouse[item] += quantity;
+    if (quantity > 1) {
+      return `田地买多了,最多买一个`; //这里我随便加了一个返回，不让买就行了
     }
-
-    this.money -= totalPrice;
-    this.saveData();
-    return `铛铛——成功购买${item}${quantity}个。`;
+    else {
+      if (item === "扩容田地") {
+        let level = globalStore[item].level;
+        if (this.purchasedFields[level]) {
+          return `你已经购买过该等级的扩容田地啦！`;
+        }
+        this.fields += quantity;
+        this.purchasedFields[level] = true;
+      } else if (item === "扩容田地ii") {
+        if (this.purchasedFields[5]) {
+          return `你已经购买过5级扩容田地啦！`;
+        }
+        this.fields += 1; // 5级扩容田地一次只能购买一个
+        this.purchasedFields[5] = true;
+        delete globalStore["扩容田地ii"]; // 购买后从商店消失
+      } else {
+        if (!this.warehouse[item]) {
+          this.warehouse[item] = 0;
+        }
+        this.warehouse[item] += quantity;
+      }
+  
+      this.money -= totalPrice;
+      this.saveData();
+      return `铛铛——成功购买${item}${quantity}个。`;
+    }
   }
 
   sellItem(item: string, quantity: number = 1) {


### PR DESCRIPTION
在群里买了12块土地2，然后发现只有九个。
此外，土地1的购买好像是一次性的（在一些群里），也许应该只有一个？
当然，我瞎说的，最后怎么改还得仓库所有者定夺，我只是提供了一种可能的思路